### PR TITLE
Firework sous pages

### DIFF
--- a/docs/msc-data/alerts/readme_alerts-datamart_en.md
+++ b/docs/msc-data/alerts/readme_alerts-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [weather warning data in the format of the Common Alerti
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file.
 
 The __data can be accessed__ at the following URLs:
 

--- a/docs/msc-data/alerts/readme_alerts-datamart_fr.md
+++ b/docs/msc-data/alerts/readme_alerts-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les [données d'avertissements météorologiques dans le form
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML.
 
 Les __bulletins sont disponibles__ à cette adresse :
 

--- a/docs/msc-data/aqhi/readme_aqhi_en.md
+++ b/docs/msc-data/aqhi/readme_aqhi_en.md
@@ -6,10 +6,8 @@
 
 # Data and Products of the Air Quality Health Index (AQHI) observation and forecast
 
-* The **Air Quality Health Index AQHI** is a scale designed to help quantify the quality of the air in a certain region on a scale from 1 to 10. When the amount of air pollution is very high, the number is reported as 10+. It also includes a category that describes the health risk associated with the index reading e.g. Low, Moderate, High, or Very High Health Risk . The AQHI is calculated based on the relative risks of a combination of common air pollutants that are known to harm human health, including ground-level ozone, particulate matter, and nitrogen dioxide. The AQHI formulation captures only the short term or acute health risk exposure of hour or days at a maximum .
+The **Air Quality Health Index AQHI** is a scale designed to help quantify the quality of the air in a certain region on a scale from 1 to 10. When the amount of air pollution is very high, the number is reported as 10+. It also includes a category that describes the health risk associated with the index reading e.g. Low, Moderate, High, or Very High Health Risk . The AQHI is calculated based on the relative risks of a combination of common air pollutants that are known to harm human health, including ground-level ozone, particulate matter, and nitrogen dioxide. The AQHI formulation captures only the short term or acute health risk exposure of hour or days at a maximum .
 The formulation of the AQHI may change over time to reflect new understanding associated with air pollution health effects. The AQHI is calculated from data observed in real time, without being verified quality control.
-
-* **Smoke from wildfires in forests and grasslands** can be a major source of air pollution for Canadians. The fine particles in the smoke can be a serious risk to health, particularly for children, seniors and those with heart or lung disease. Because smoke may be carried thousands of kilometres downwind, distant locations can be affected almost as severely as areas close to the fire. To help Canadians be better prepared, wildfire smoke forecast maps are available through the Government of Canada’s FireWork system. FireWork is an air quality prediction system that indicates how smoke from wildfires is expected to move across North America over the next 48 hours.
 
 ## Access
 
@@ -19,7 +17,6 @@ These data are available on the data server services [MSC Datamart](../../msc-da
 
 * [CSV data for AQHI, available on the MSC Datamart](readme_aqhi-datamartcsv_en.md), including chemical species forecast data from numerical air quality models
 * [XML data for AQHI, available on the MSC Datamart](readme_aqhi-datamartxml_en.md) 
-* [Firework data available via geospatial web services GeoMet-Weather](../../msc-geomet/readme_en.md)
 
 An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is available.
 
@@ -35,7 +32,6 @@ The [metadata of the Air Quality Health Index (AQHI) observation and forecast ar
 
 * [Summary of the most recent Air Quality Health Index forecasts for a large number of cities in Canada](https://weather.gc.ca/airquality/pages/index_e.html)
 * [Charts of forecasts of ozone, PM2.5 and PM10 near surface and at different altitudes](https://weather.gc.ca/aqfm/index_e.html)
-* [Daily smoke forecast maps, from early April to late October](https://weather.gc.ca/firework/index_e.html)
 
 ## Partners
 
@@ -60,7 +56,6 @@ Health Services Department, Durham Region Health Department, Ottawa Public Healt
 ## Technical documentation
 
 * [Guide to Air Quality Health Index forecasts](https://www.canada.ca/en/environment-climate-change/services/weather-health/publications/guide-air-quality-index-forecasts.html)
-* [Technical note of the Regional Air Quality Deterministic Prediction System (RAQDPS) and FireWork Prediction System](https://collaboration.cmc.ec.gc.ca/cmc/CMOI/product_guide/docs/tech_notes/technote_raqdps_e.pdf)
 
 ## Change log
 

--- a/docs/msc-data/aqhi/readme_aqhi_fr.md
+++ b/docs/msc-data/aqhi/readme_aqhi_fr.md
@@ -6,10 +6,8 @@
 
 # Données et produits d'observations et prévisions qui sont générés pour le programme Cote Air Santé (CAS)
 
-* La **cote air santé CAS** est une échelle conçue pour quantifier la qualité de l'air dans une région donnée, sur une échelle de 1 à 10. La cote 10+ indique que la pollution de l'air est très élevée. La cote air santé comprend également une catégorie décrivant le risque pour la santé correspondant au nombre indiqué risque faible, modéré, élevé ou très élevé . La cote air santé est calculée en fonction des risques relatifs que représente une combinaison de polluants atmosphériques courants connus pour leurs effets néfastes sur la santé humaine, tels que l'ozone troposphérique, les matières particulaires et le dioxyde d'azote. La formulation de la cote air santé rend uniquement compte du risque pour la santé aigu ou à court terme contact en heures ou en jours au maximum .
+La **cote air santé CAS** est une échelle conçue pour quantifier la qualité de l'air dans une région donnée, sur une échelle de 1 à 10. La cote 10+ indique que la pollution de l'air est très élevée. La cote air santé comprend également une catégorie décrivant le risque pour la santé correspondant au nombre indiqué risque faible, modéré, élevé ou très élevé . La cote air santé est calculée en fonction des risques relatifs que représente une combinaison de polluants atmosphériques courants connus pour leurs effets néfastes sur la santé humaine, tels que l'ozone troposphérique, les matières particulaires et le dioxyde d'azote. La formulation de la cote air santé rend uniquement compte du risque pour la santé aigu ou à court terme contact en heures ou en jours au maximum .
 Cette formulation pourrait changer avec le temps, pour rendre compte d'une nouvelle compréhension des effets de la pollution atmosphérique sur la santé. La cote air santé est calculée à partir de données observées en temps réel, sans vérification contrôle de la qualité.
-
-* La **fumée des feux de forêt et de broussailles** peut constituer une source importante de pollution de l’air pour les Canadiens. Les particules fines présentes dans la fumée peuvent représenter un risque grave pour la santé, en particulier pour les enfants, les personnes âgées et les gens souffrant de maladies cardiaques ou pulmonaires. Comme la fumée peut être transportée par le vent sur des milliers de kilomètres, des endroits éloignés peuvent être presque aussi durement touchés que les régions près de l’incendie. Afin d’aider les Canadiens à mieux se préparer, des cartes de prévisions sur la fumée des feux de forêt sont accessibles par le biais du système FireWork du gouvernement du Canada. FireWork est un système de prévision de la qualité de l’air indiquant comment la fumée des feux de forêt devrait traverser l’Amérique du Nord pendant les 48 prochaines heures.
 
 ## Accès
 
@@ -19,7 +17,6 @@ Ces données sont respectivement disponibles sur les services serveur de donnée
 
 * [Données pour la CAS, disponibles en format CSV sur le Datamart du SMC](readme_aqhi-datamartcsv_fr.md), dont des données de prévisions d'espèces chimiques provenant de modèles numériques de qualité de l'air
 * [Données pour la CAS, disponibles en format XML sur le Datamart du SMC](readme_aqhi-datamartxml_fr.md)
-* [Données Firework disponibles via les services web géospatiaux GeoMet-Météo](../../msc-geomet/readme_fr.md)
 
 Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est disponible.
 
@@ -35,7 +32,6 @@ Les [métadonnées d'observations et prévisions qui sont générés pour le pro
 
 * [Sommaire des prévisions les plus récentes de la Cote air santé dans un grand nombre de villes au Canada](https://meteo.gc.ca/airquality/pages/index_f.html)
 * [Carte de prévisions de l'ozone, PM2.5, et PM10 près de la surface et à différentes altitudes](https://meteo.gc.ca/aqfm/index_f.html)
-* [Cartes des prévisions quotidiennes sur la fumée, disponibles du début avril jusqu’à la fin octobre](https://meteo.gc.ca/firework/index_f.html)
 
 ## Partenaires
 
@@ -57,7 +53,6 @@ Le programme CAS est un partenariat conjoint d'Environnement et Changement clima
 ## Documentation technique
 
 * [Guide des prévisions de la côte air santé ](https://www.canada.ca/fr/environnement-changement-climatique/services/meteo-sante/publications/guide-previsions-cote-air-sante.html)
-* [Note technique du Système régional de prévision déterministe de la qualité de l'air (SRPDQA) et du système de prévision FireWork](https://collaboration.cmc.ec.gc.ca/cmc/CMOI/product_guide/docs/tech_notes/technote_raqdps_f.pdf)
 
 ## Registre des changements 
 

--- a/docs/msc-data/nwp_geps/readme_geps-datamart_en.md
+++ b/docs/msc-data/nwp_geps/readme_geps-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [Global Ensemble Prediction System](readme_geps_en.md) d
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URLs :
 

--- a/docs/msc-data/nwp_geps/readme_geps-datamart_fr.md
+++ b/docs/msc-data/nwp_geps/readme_geps-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données du [Système global de prévision d'ensemble](re
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le Protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. 
 
 Les données sont accessibles aux adresses suivantes :
 

--- a/docs/msc-data/nwp_hrdpa/readme_hrdpa-datamart_en.md
+++ b/docs/msc-data/nwp_hrdpa/readme_hrdpa-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [High Resolution Deterministic Precipitation Analysis](.
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URLs :
 

--- a/docs/msc-data/nwp_hrdpa/readme_hrdpa-datamart_fr.md
+++ b/docs/msc-data/nwp_hrdpa/readme_hrdpa-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données de l'[Analyse à haute résolution déterministe
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2.
 
 Les données sont accessibles aux adresses suivantes :
 

--- a/docs/msc-data/nwp_hrdps/readme_hrdps-datamart-alpha_en.md
+++ b/docs/msc-data/nwp_hrdps/readme_hrdps-datamart-alpha_en.md
@@ -18,7 +18,7 @@ Since the original implementation of the HRDPS 1 km west, the system has been ru
 
 MSC testing data repository DD-Alpha data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URL:
 

--- a/docs/msc-data/nwp_hrdps/readme_hrdps-datamart-alpha_fr.md
+++ b/docs/msc-data/nwp_hrdps/readme_hrdps-datamart-alpha_fr.md
@@ -18,7 +18,7 @@ Depuis la mise en œuvre initiale du SHRPD 1 km ouest, le système fonctionne 2 
 
 Les données du site web d'essai de données DD-Alpha du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2.
 
 Les données sont accessibles à l'adresse suivante :
 

--- a/docs/msc-data/nwp_hrdps/readme_hrdps-datamart_en.md
+++ b/docs/msc-data/nwp_hrdps/readme_hrdps-datamart_en.md
@@ -16,7 +16,7 @@ The HRDPS not yet being equipped with its own data assimilation system, so its q
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URL:
 

--- a/docs/msc-data/nwp_hrdps/readme_hrdps-datamart_fr.md
+++ b/docs/msc-data/nwp_hrdps/readme_hrdps-datamart_fr.md
@@ -17,7 +17,7 @@ Le SHRPD n’étant pas équipé de son propre système d’assimilation de donn
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2.
 
 Les données sont accessibles à l'adresse suivante :
 

--- a/docs/msc-data/nwp_nowcasting/readme_nowcasting-datamart_en.md
+++ b/docs/msc-data/nwp_nowcasting/readme_nowcasting-datamart_en.md
@@ -16,7 +16,7 @@ Numerical Weather Prediction models, Statistical models and Nowcasting systems a
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URLs :
 

--- a/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw-datamart_en.md
+++ b/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw-datamart_en.md
@@ -1,0 +1,42 @@
+[En français](readme_raqdps-fw-datamart_fr.md)
+
+![ECCC logo](../../img_eccc-logo.png)
+
+[TOC](../../readme_en.md) > [MSC data](../readme_en.md) > [RAQDPS-FW](readme_raqdps-fw_en.md) > FireWork Prediction System on MSC Datamart
+
+# FireWork Prediction System Data in GRIB2 Format
+
+XXXX
+
+## Data location
+
+MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
+
+The data can be accessed at the following URLs:
+
+* []()
+
+A history of XXXX days of forecast is kept in this directory.
+
+## File nomenclature
+
+NOTE: ALL HOURS ARE IN UTC.
+
+The files have the following nomenclature:
+
+* XXXXXX
+
+where:
+
+* __xx__ : XXXXXX
+
+Example of forecast file name:
+* XXXX
+
+## Support
+
+If you have any questions about these data, please contact us at: [ec.dps-client.ec@canada.ca](mailto:ec.dps-client.ec@canada.ca)
+
+## Announcements from the dd_info mailing list 
+
+Announcements related to this dataset are available in the [dd_info list](https://lists.ec.gc.ca/cgi-bin/mailman/listinfo/dd_info).

--- a/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw-datamart_fr.md
+++ b/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw-datamart_fr.md
@@ -1,0 +1,45 @@
+[In English](readme_raqdps-fw-datamart_en.md)
+
+![ECCC logo](../../img_eccc-logo.png)
+
+[TdM](../../readme_fr.md) > [Données du SMC](../readme_fr.md) > [SRPDQA-FW](readme_raqdps-fw_fr.md) > Système de prévision FireWork sur le Datamart du SMC
+
+# Données GRIB2 du Système de prévision FireWork
+
+XXXXXX
+
+## Adresse des données 
+
+Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le Protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
+
+Les données sont accessibles à l'adresses suivante :
+
+* []()                  
+
+Un historique de XXX jours de prévision est stocké dans ce répertoire.
+
+
+## Nomenclature des noms de fichiers 
+
+NOTE: TOUTES LES HEURES SONT EN UTC.
+
+La nomenclature des noms des fichiers suivante :
+
+* XXXXXX
+
+où :
+
+* __xx__ : XXXXXX
+
+Exemple de nom de fichier de prévision :
+
+* XXXX
+
+
+## Support
+
+Pour toute question relative à ces données, merci de nous contacter à l'adresse : [ec.dps-client.ec@canada.ca](mailto:ec.dps-client.ec@canada.ca)
+
+## Annonces de la liste de diffusion dd_info 
+
+Les annonces reliées à ce jeu de données sont disponibles via la liste [dd_info](https://lists.ec.gc.ca/cgi-bin/mailman/listinfo/dd_info).

--- a/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw_en.md
+++ b/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw_en.md
@@ -1,0 +1,40 @@
+[En français](readme_raqdps-fw_fr.md)
+
+![ECCC logo](../../img_eccc-logo.png)
+
+[TOC](../../readme_en.md) > [MSC data](../readme_en.md) > FireWork Prediction System
+
+# Data and Products of the FireWork Prediction System
+
+**Smoke from wildfires in forests and grasslands** can be a major source of air pollution for Canadians. The fine particles in the smoke can be a serious risk to health, particularly for children, seniors and those with heart or lung disease. Because smoke may be carried thousands of kilometres downwind, distant locations can be affected almost as severely as areas close to the fire. To help Canadians be better prepared, wildfire smoke forecast maps are available through the Government of Canada’s FireWork system. FireWork is an air quality prediction system that indicates how smoke from wildfires is expected to move across North America over the next 48 hours.
+
+## Access
+
+### How to access the data
+
+These data are available on the data server services [MSC Datamart](../../msc-datamart/readme_en.md) and the web services [MSC GeoMet](../../msc-geomet/readme_en.md) respectively:
+
+* [Firework data available via geospatial web services GeoMet-Weather](../../msc-geomet/readme_en.md)
+
+An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is available.
+
+### Licence
+
+The [end-user licence for Environment and Climate Change Canada's data servers](../../licence/readme_en.md) specifies the conditions of use of these data.
+
+### Metadata
+
+Upcoming.
+
+## Products
+
+* [Daily smoke forecast maps, from early April to late October](https://weather.gc.ca/firework/index_e.html)
+
+## Technical documentation
+
+* [Technical note of the Regional Air Quality Deterministic Prediction System (RAQDPS) and FireWork Prediction System](https://collaboration.cmc.ec.gc.ca/cmc/CMOI/product_guide/docs/tech_notes/technote_raqdps_e.pdf)
+
+## Change log
+
+The chronology of changes to operational systems is available [here](https://collaboration.cmc.ec.gc.ca/cmc/cmoi/product_guide/docs/changes_e.html).
+

--- a/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw_fr.md
+++ b/docs/msc-data/nwp_raqdps-fw/readme_raqdps-fw_fr.md
@@ -1,0 +1,39 @@
+[In English](readme_raqdps-fw_en.md)
+
+![ECCC logo](../../img_eccc-logo.png)
+
+[TdM](../../readme_fr.md) > [Données du SMC](../readme_fr.md) > Système de prévision FireWork
+
+# Données et Produits du Système de prévision FireWork
+
+La **fumée des feux de forêt et de broussailles** peut constituer une source importante de pollution de l’air pour les Canadiens. Les particules fines présentes dans la fumée peuvent représenter un risque grave pour la santé, en particulier pour les enfants, les personnes âgées et les gens souffrant de maladies cardiaques ou pulmonaires. Comme la fumée peut être transportée par le vent sur des milliers de kilomètres, des endroits éloignés peuvent être presque aussi durement touchés que les régions près de l’incendie. Afin d’aider les Canadiens à mieux se préparer, des cartes de prévisions sur la fumée des feux de forêt sont accessibles par le biais du système FireWork du gouvernement du Canada. FireWork est un système de prévision de la qualité de l’air indiquant comment la fumée des feux de forêt devrait traverser l’Amérique du Nord pendant les 48 prochaines heures.
+
+## Accès
+
+### Comment accéder aux données
+
+Ces données sont respectivement disponibles sur les services serveur de données [Datamart du SMC](../../msc-datamart/readme_fr.md) et les services web [GeoMet du SMC](../../msc-geomet/readme_fr.md) :
+
+* [Données Firework disponibles via les services web géospatiaux GeoMet-Météo](../../msc-geomet/readme_fr.md)
+
+Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est disponible.
+
+### Licence
+
+La [licence d’utilisation finale pour les serveurs de données d’Environnement et Changement climatique Canada](../../licence/readme_fr.md) précise les conditions d'utilisation de ces données.
+
+### Métadonnées
+
+À venir.
+
+## Produits
+
+* [Cartes des prévisions quotidiennes sur la fumée, disponibles du début avril jusqu’à la fin octobre](https://meteo.gc.ca/firework/index_f.html)
+
+## Documentation technique
+
+* [Note technique du Système régional de prévision déterministe de la qualité de l'air (SRPDQA) et du système de prévision FireWork](https://collaboration.cmc.ec.gc.ca/cmc/CMOI/product_guide/docs/tech_notes/technote_raqdps_f.pdf)
+
+## Registre des changements 
+
+La chronologie des changements apportés aux systèmes opérationnels est disponible [ici](https://collaboration.cmc.ec.gc.ca/cmc/cmoi/product_guide/docs/changes_f.html).

--- a/docs/msc-data/nwp_rdps-cgsl/readme_rdps-cgsl-datamart_en.md
+++ b/docs/msc-data/nwp_rdps-cgsl/readme_rdps-cgsl-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [Atmosphere-Ocean-Ice forecast system for the Gulf of St
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URLs :
 

--- a/docs/msc-data/nwp_rdps-cgsl/readme_rdps-cgsl-datamart_fr.md
+++ b/docs/msc-data/nwp_rdps-cgsl/readme_rdps-cgsl-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données [système régional de prévision déterministe 
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2.
 
 Les données sont accessibles aux adresses suivantes :
 

--- a/docs/msc-data/nwp_rdwps/readme_rdwps-datamart_en.md
+++ b/docs/msc-data/nwp_rdwps/readme_rdwps-datamart_en.md
@@ -33,7 +33,7 @@ WAM (WAve Model) (WAMDI Group 1988, Komen et al. 1994) is a third generation spe
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file.
 
 The data can be accessed at the following URLs :
 

--- a/docs/msc-data/nwp_reps/readme_reps-datamart_en.md
+++ b/docs/msc-data/nwp_reps/readme_reps-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [Regional Ensemble Prediction System](readme_reps_en.md)
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable GRIB2 file. 
 
 The data can be accessed at the following URLs:
 

--- a/docs/msc-data/nwp_reps/readme_reps-datamart_fr.md
+++ b/docs/msc-data/nwp_reps/readme_reps-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données du [système régional de prévision d'ensemble]
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier GRIB2.
 
 Les données sont accessibles aux adresses suivantes :
 

--- a/docs/msc-data/nwp_wcps/readme_wcps_nemo-datamart_fr.md
+++ b/docs/msc-data/nwp_wcps/readme_wcps_nemo-datamart_fr.md
@@ -12,7 +12,7 @@ Le modèle océan-glace, NEMO-CICE, du SPCE, produit des prévisions horaires. C
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le Protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier netCDF. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier netCDF.
 
 Les données sont accessibles à l'adresse suivante :
 

--- a/docs/msc-data/obs_hydrometric/readme_hydrometric-datamart_en.md
+++ b/docs/msc-data/obs_hydrometric/readme_hydrometric-datamart_en.md
@@ -12,7 +12,7 @@ This page describes the [real time hydrometric](readme_hydrometric_en.md) data a
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable CSV file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable CSV file.
 
 The data is available at the following address:
 

--- a/docs/msc-data/obs_hydrometric/readme_hydrometric-datamart_fr.md
+++ b/docs/msc-data/obs_hydrometric/readme_hydrometric-datamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données [hydrométriques en temps réel](readme_hydromet
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier CSV. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier CSV.
 
 Les fichiers pour ces données se trouvent à l'adresse :
 

--- a/docs/msc-data/obs_station/readme_obs_insitu_swobdatamart_en.md
+++ b/docs/msc-data/obs_station/readme_obs_insitu_swobdatamart_en.md
@@ -12,7 +12,7 @@ This page describes the [surface weather and marine observation](readme_obs_insi
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file.
 
 Data are available at the following addresses :
 

--- a/docs/msc-data/obs_station/readme_obs_insitu_swobdatamart_fr.md
+++ b/docs/msc-data/obs_station/readme_obs_insitu_swobdatamart_fr.md
@@ -12,7 +12,7 @@ Cette page décrit les données des [observations](readme_obs_insitu_fr.md) mét
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML.
 
 Les données sont disponibles aux adresses suivantes :
 

--- a/docs/msc-data/obs_station/readme_obs_insitu_xmldatamart_en.md
+++ b/docs/msc-data/obs_station/readme_obs_insitu_xmldatamart_en.md
@@ -28,7 +28,7 @@ There are 6 XML files for each province/territory as follows:
 
 MSC Datamart data can be [automatically retrieved with the Advanced Message Queuing Protocol (AMQP)](../../msc-datamart/amqp_en.md) as soon as they become available. An [overview and examples to access and use the Meteorological Service of Canada's open data](../../usage/readme_en.md) is also available.
 
-The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file. In practice, we recommend writing your own script to automate the downloading of the desired data (using wget or equivalent). If you are unsure of how to proceed, you might like to take a look at our brief wget usage guide.
+The data is available using the HTTP protocol and resides in a directory that is plainly accessible to a web browser. Visiting that directory with an interactive browser will yield a raw listing of links, each link being a downloadable XML file.
 
 The provincial and territorial summary XML files are grouped in a directory tree that is based on the province/territory and the summary type.
 

--- a/docs/msc-data/obs_station/readme_obs_insitu_xmldatamart_fr.md
+++ b/docs/msc-data/obs_station/readme_obs_insitu_xmldatamart_fr.md
@@ -22,7 +22,7 @@ Il y a 6 types de fichiers pour chaque province ou territoire :
 
 Les données du Datamart du SMC peuvent être [automatiquement récupérées avec le protocole avancé de mise en file d'attente des messages (AMQP)](../../msc-datamart/amqp_fr.md) dès qu'elles deviennent disponibles. Un [survol et exemples pour accéder et utiliser les données ouvertes du Service météorologique du Canada](../../usage/readme_fr.md) est également disponible.
 
-Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML. Nous vous recommandons d’automatiser le téléchargement en le scriptant avec wget (lien externe, anglais) ou un programme équivalent. Pour plus d’information sur wget, consultez les notes d’utilisation.
+Les données sont disponibles via le protocole HTTP. Il est possible d’y accéder avec un fureteur standard. Dans ce cas, on obtient une liste de liens donnant accès à un fichier XML.
 
 Les fichiers XML du sommaire des observations des provinces ou des territoires sont regroupés dans une structure de répertoires basée sur la province/territoire et le type de sommaire.
 


### PR DESCRIPTION
Créations des pages haut et bas niveau de RAQDPS-FW. Mentions du système Firework retirés des pages AQHI. Manque d'informations pour compléter adéquatement les pages -datamart_en & _fr.md.