### PR TITLE
Fix typo in oceanic variables data source issue-1212

### DIFF
--- a/docs/msc-data/nwp_caps/readme_caps-datamart_en.md
+++ b/docs/msc-data/nwp_caps/readme_caps-datamart_en.md
@@ -87,7 +87,7 @@ Examples of file names:
 <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest"></script>
 <script src="../../../js/variables_datatable.js" type="text/javascript"></script>
 <script>
-  loadTable("csv-table-netcdf", "../../../assets/csv/RIOPS_Variables-List_fr.csv");
+  loadTable("csv-table-netcdf", "../../../assets/csv/RIOPS_Variables-List_en.csv");
 </script>
 
 ## Support


### PR DESCRIPTION
Fixed a small typo where the French version of the oceanic variables data was being requested on the English version of the documentation.