### PR TITLE
Fix typo in oceanic variables data source redo issue-1212

### DIFF
--- a/docs/msc-data/nwp_caps/readme_caps-datamart_en.md
+++ b/docs/msc-data/nwp_caps/readme_caps-datamart_en.md
@@ -87,7 +87,7 @@ Examples of file names:
 <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest"></script>
 <script src="../../../js/variables_datatable.js" type="text/javascript"></script>
 <script>
-  loadTable("csv-table-netcdf", "../../../assets/csv/RIOPS_Variables-List_fr.csv");
+  loadTable("csv-table-netcdf", "../../../assets/csv/RIOPS_Variables-List_en.csv");
 </script>
 
 ## Support


### PR DESCRIPTION
Changed the CAPS on MSC Datamart page's English version to obtain data from the English Oceanic Variables data source instead of the French one. CC @alexandreleroux